### PR TITLE
fix: 多文件编辑时，文件路径有中文或者特殊字符会被转义，应该怎么处理

### DIFF
--- a/demo/app.tsx
+++ b/demo/app.tsx
@@ -45,7 +45,7 @@ const App = () => {
         Promise.all(promises).then(filesContent => {
             const res:filelist = {};
             filesContent.forEach((content, index) => {
-                res[filesName[index]] = content;
+                res[decodeURIComponent(filesName[index])] = content;
             });
             unstable_batchedUpdates(() => {
                 setFiles(res);


### PR DESCRIPTION
Closes #5

Patch generated by `qwen3.6-35b-a3b via local API`.